### PR TITLE
Datetime scaling

### DIFF
--- a/src/fritter/boundaries.py
+++ b/src/fritter/boundaries.py
@@ -370,6 +370,35 @@ class Scheduler(Protocol[WhenT, WhatT, IDTCo]):
 PhysicalScheduler = Scheduler[float, Callable[[], None], object]
 CivilScheduler = Scheduler[DateTime[ZoneInfo], Callable[[], None], object]
 
+_BranchTime = TypeVar("_BranchTime", bound=PriorityComparable)
+_TrunkTime = TypeVar("_TrunkTime", bound=PriorityComparable)
+_TrunkDelta = TypeVar("_TrunkDelta")
+
+
+class Scale(Protocol[_BranchTime, _TrunkTime, _TrunkDelta]):
+    """
+    A L{Scale} defines a translation between a branch (i.e., "child") time
+    scale, and a trunk (i.e., "parent") time scale.
+    """
+
+    def up(self, offset: _TrunkDelta, time: _BranchTime) -> _TrunkTime:
+        """
+        Translate C{time} from the branch time scale into the trunk time scale.
+        """
+
+    def down(self, offset: _TrunkDelta, time: _TrunkTime) -> _BranchTime:
+        """
+        Translate C{time} from the trunk time scale into the branch time scale.
+        """
+
+    def shift(
+        self, pauseTime: _BranchTime | None, currentTime: _TrunkTime
+    ) -> _TrunkDelta:
+        """
+        Shift the current scale forward to incorporate
+        """
+
+
 __all__ = [
     "AsyncDriver",
     "Cancellable",

--- a/src/fritter/drivers/datetimes.py
+++ b/src/fritter/drivers/datetimes.py
@@ -73,6 +73,7 @@ class DateScale:
     """
 
     _zone: ZoneInfo
+    _onlyPauseShift: bool = True
 
     def up(self, offset: float, time: DateTime[ZoneInfo]) -> float:
         """
@@ -92,6 +93,8 @@ class DateScale:
         """
         Shift the current scale forward to incorporate pause breaks.
         """
+        if self._onlyPauseShift and pauseTime is None:
+            return 0.0
         return (
             currentTime
             if pauseTime is None

--- a/src/fritter/drivers/datetimes.py
+++ b/src/fritter/drivers/datetimes.py
@@ -84,7 +84,7 @@ class DateScale:
         """
         Translate C{time} from the trunk time scale into the branch time scale.
         """
-        return DateTime.fromtimestamp(time + offset, self._zone)
+        return DateTime.fromtimestamp(time - offset, self._zone)
 
     def shift(
         self, pauseTime: DateTime[ZoneInfo] | None, currentTime: float
@@ -92,10 +92,11 @@ class DateScale:
         """
         Shift the current scale forward to incorporate pause breaks.
         """
-        if pauseTime is None:
-            return currentTime
-        else:
-            return currentTime - pauseTime.timestamp()
+        return (
+            currentTime
+            if pauseTime is None
+            else currentTime - pauseTime.timestamp()
+        )
 
 
 _DateScaleTypeCheck: type[Scale[DateTime[ZoneInfo], float, float]] = DateScale

--- a/src/fritter/drivers/datetimes.py
+++ b/src/fritter/drivers/datetimes.py
@@ -1,6 +1,6 @@
 """
-Implementation of L{TimeDriver} to convert floating-point POSIX timestamps into
-timezone-aware datetimes.
+Implementation of a L{TimeDriver} and a L{Scale} to convert floating-point
+POSIX timestamps into timezone-aware datetimes.
 
 @note: Although at runtime this module uses L{datetime.datetime} objects, its
     type hints use the U{datetype <https://pypi.org/project/datetype/>} library
@@ -18,7 +18,17 @@ from zoneinfo import ZoneInfo
 
 from datetype import DateTime
 
-from ..boundaries import TimeDriver
+from ..boundaries import (
+    TimeDriver,
+    Scale,
+)
+
+
+__all__ = [
+    "guessLocalZone",
+    "DateScale",
+    "DateTimeDriver",
+]
 
 _PS_TZ_CMD = """\
 powershell \
@@ -52,6 +62,43 @@ def guessLocalZone() -> ZoneInfo:
         ianaID = "/".join(path[path.index("zoneinfo") + 1 :])
     _guessedZone = ZoneInfo(ianaID)
     return _guessedZone
+
+
+@dataclass
+class DateScale:
+    """
+    A L{fritter.boundaries.Scale} that can scale between a trunk scheduler that
+    uses physical time (floats) and a branch scheduler that uses civil time
+    (dates and wall-clock times).
+    """
+
+    _zone: ZoneInfo
+
+    def up(self, offset: float, time: DateTime[ZoneInfo]) -> float:
+        """
+        Translate C{time} from the branch time scale into the trunk time scale.
+        """
+        return time.timestamp() + offset
+
+    def down(self, offset: float, time: float) -> DateTime[ZoneInfo]:
+        """
+        Translate C{time} from the trunk time scale into the branch time scale.
+        """
+        return DateTime.fromtimestamp(time + offset, self._zone)
+
+    def shift(
+        self, pauseTime: DateTime[ZoneInfo] | None, currentTime: float
+    ) -> float:
+        """
+        Shift the current scale forward to incorporate pause breaks.
+        """
+        if pauseTime is None:
+            return currentTime
+        else:
+            return currentTime - pauseTime.timestamp()
+
+
+_DateScaleTypeCheck: type[Scale[DateTime[ZoneInfo], float, float]] = DateScale
 
 
 @dataclass(frozen=True)

--- a/src/fritter/test/test_tree.py
+++ b/src/fritter/test/test_tree.py
@@ -257,8 +257,6 @@ class RecursiveTest(TestCase):
         self.assertEqual(startPoint, dateScheduler.now())
 
 
-
-
 def timestampRecorder(
     calls: list[tuple[float, float]],
     scheduler1: PhysicalScheduler,

--- a/src/fritter/test/test_tree.py
+++ b/src/fritter/test/test_tree.py
@@ -234,6 +234,30 @@ class RecursiveTest(TestCase):
             startPoint + timedelta(seconds=11.0), dateScheduler.now()
         )
 
+    def test_dateScalingInitialScale(self) -> None:
+        """
+        L{DateScale} defaults to ignoring the initial offset of its float trunk
+        scheduler.
+        """
+        scheduler1: PhysicalScheduler = schedulerFromDriver(
+            driver := MemoryDriver(),
+        )
+        driver.advance(1765333209)
+        tz = ZoneInfo("US/Pacific")
+        dateScheduler: Scheduler[DateTime[ZoneInfo], Callable[[], None], int]
+        mgr, dateScheduler = branch(scheduler1, DateScale(tz))
+        self.assertFalse(driver.isScheduled())
+        startPoint = aware(
+            datetime(2025, 12, 9, 18, 20, 9, tzinfo=tz), ZoneInfo
+        )
+        self.assertEqual(startPoint, dateScheduler.now())
+        mgr.pause()
+        driver.advance(250.0)
+        mgr.unpause()
+        self.assertEqual(startPoint, dateScheduler.now())
+
+
+
 
 def timestampRecorder(
     calls: list[tuple[float, float]],

--- a/src/fritter/test/test_tree.py
+++ b/src/fritter/test/test_tree.py
@@ -3,10 +3,10 @@ from typing import Callable, List, Tuple
 from unittest import TestCase
 from zoneinfo import ZoneInfo
 
-from datetype import DateTime
+from datetype import DateTime, aware
 
-from ..boundaries import CivilScheduler, PhysicalScheduler
-from ..drivers.datetimes import DateTimeDriver
+from ..boundaries import CivilScheduler, PhysicalScheduler, Scheduler
+from ..drivers.datetimes import DateScale, DateTimeDriver
 from ..drivers.memory import MemoryDriver
 from ..scheduler import schedulerFromDriver
 from ..tree import _BranchDriver, branch, timesFaster
@@ -200,6 +200,39 @@ class RecursiveTest(TestCase):
         self.assertTrue(driver.isScheduled())
         onlyCall.cancel()
         self.assertFalse(driver.isScheduled())
+
+    def test_dateScaling(self) -> None:
+        """
+        L{DateScale} will scale a physical root-scheduler into a
+        timestamp/datetime-based civil time scheduler.
+        """
+        scheduler1: PhysicalScheduler = schedulerFromDriver(
+            driver := MemoryDriver(),
+        )
+        tz = ZoneInfo("US/Pacific")
+        dateScheduler: Scheduler[DateTime[ZoneInfo], Callable[[], None], int]
+        mgr, dateScheduler = branch(scheduler1, DateScale(tz))
+        self.assertFalse(driver.isScheduled())
+        driver.advance(1765333209)
+        startPoint = aware(
+            datetime(2025, 12, 9, 18, 20, 9, tzinfo=tz), ZoneInfo
+        )
+        self.assertEqual(startPoint, dateScheduler.now())
+        mgr.pause()
+        driver.advance(250.0)
+        mgr.unpause()
+        self.assertEqual(startPoint, dateScheduler.now())
+        called = []
+        dateScheduler.callAt(
+            startPoint + timedelta(seconds=10), lambda: called.append(1)
+        )
+        driver.advance(9.0)
+        self.assertEqual(called, [])
+        driver.advance(2.0)
+        self.assertEqual(called, [1])
+        self.assertEqual(
+            startPoint + timedelta(seconds=11.0), dateScheduler.now()
+        )
 
 
 def timestampRecorder(

--- a/src/fritter/tree.py
+++ b/src/fritter/tree.py
@@ -25,36 +25,16 @@ if version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
-from .boundaries import Cancellable, PriorityComparable, Scheduler
+from .boundaries import (
+    Cancellable,
+    PriorityComparable,
+    Scheduler,
+    Scale,
+    _BranchTime,
+    _TrunkTime,
+    _TrunkDelta,
+)
 from .scheduler import schedulerFromDriver
-
-_BranchTime = TypeVar("_BranchTime", bound=PriorityComparable)
-_TrunkTime = TypeVar("_TrunkTime", bound=PriorityComparable)
-_TrunkDelta = TypeVar("_TrunkDelta")
-
-
-class Scale(Protocol[_BranchTime, _TrunkTime, _TrunkDelta]):
-    """
-    A L{Scale} defines a translation between a branch (i.e., "child") time
-    scale, and a trunk (i.e., "parent") time scale.
-    """
-
-    def up(self, offset: _TrunkDelta, time: _BranchTime) -> _TrunkTime:
-        """
-        Translate C{time} from the branch time scale into the trunk time scale.
-        """
-
-    def down(self, offset: _TrunkDelta, time: _TrunkTime) -> _BranchTime:
-        """
-        Translate C{time} from the trunk time scale into the branch time scale.
-        """
-
-    def shift(
-        self, pauseTime: _BranchTime | None, currentTime: _TrunkTime
-    ) -> _TrunkDelta:
-        """
-        Shift the current scale forward to incorporate
-        """
 
 
 DT = TypeVar("DT")
@@ -201,7 +181,7 @@ def branch(
 def branch(
     trunk: Scheduler[_BranchTime, Callable[[], None], object],
 ) -> tuple[
-    BranchManager[_BranchTime, _BranchTime, _TrunkDelta],
+    BranchManager[_BranchTime, _BranchTime, _Deltable[_BranchTime]],
     Scheduler[_BranchTime, Callable[[], None], int],
 ]: ...
 

--- a/src/fritter/tree.py
+++ b/src/fritter/tree.py
@@ -155,14 +155,16 @@ def timesFaster(factor: float) -> Scale[float, float, float]:
     return _FloatScale(factor)
 
 
-class BranchManager(Protocol[WhenT, _TrunkDelta]):
+class BranchManager(Protocol[_BranchTime, _TrunkTime, _TrunkDelta]):
     """
     A L{BranchManager} controls a group of timers in a branch scheduler created
     with L{branch}; pausing the passage of time in the branch, unpausing it, or
     making its relative rate of progress faster or slower.
     """
 
-    def changeScale(self, scale: Scale[WhenT, WhenT, _TrunkDelta]) -> None:
+    def changeScale(
+        self, scale: Scale[_BranchTime, _TrunkTime, _TrunkDelta]
+    ) -> None:
         """
         Change the relative scale of the time coordinate system for this branch
         and for its trunk to the new, given C{scale}.  i.e.: with a scale of
@@ -187,40 +189,41 @@ class BranchManager(Protocol[WhenT, _TrunkDelta]):
 
 @overload
 def branch(
-    trunk: Scheduler[WhenT, Callable[[], None], object],
-    scale: Scale[WhenT, WhenT, _TrunkDelta],
+    trunk: Scheduler[_TrunkTime, Callable[[], None], object],
+    scale: Scale[_BranchTime, _TrunkTime, _TrunkDelta],
 ) -> tuple[
-    BranchManager[WhenT, _TrunkDelta],
-    Scheduler[WhenT, Callable[[], None], int],
+    BranchManager[_BranchTime, _TrunkTime, _TrunkDelta],
+    Scheduler[_BranchTime, Callable[[], None], int],
 ]: ...
 
 
 @overload
-def branch(trunk: Scheduler[WhenT, Callable[[], None], object]) -> tuple[
-    BranchManager[WhenT, WhenT],
-    Scheduler[WhenT, Callable[[], None], int],
+def branch(
+    trunk: Scheduler[_BranchTime, Callable[[], None], object],
+) -> tuple[
+    BranchManager[_BranchTime, _BranchTime, _TrunkDelta],
+    Scheduler[_BranchTime, Callable[[], None], int],
 ]: ...
 
 
 def branch(
-    trunk: Scheduler[WhenT, Callable[[], None], object],
-    scale: Scale[WhenT, WhenT, _TrunkDelta] | None = None,
+    trunk: Scheduler[_TrunkTime, Callable[[], None], object],
+    scale: Scale[_BranchTime, _TrunkTime, _TrunkDelta] | None = None,
 ) -> tuple[
-    BranchManager[WhenT, _TrunkDelta],
-    Scheduler[WhenT, Callable[[], None], int],
+    BranchManager[_BranchTime, _TrunkTime, _TrunkDelta],
+    Scheduler[_BranchTime, Callable[[], None], int],
 ]:
     """
     Derive a branch (child) scheduler from a C{trunk} (parent) scheduler.
     """
     if scale is None:
-        scale = NoScale[_TrunkDelta]()
-        # scale = timesFaster(1)  # type:ignore
+        scale = NoScale[_TrunkDelta]()  # type:ignore
     assert scale is not None
-    driver: _BranchDriver[WhenT, WhenT, _TrunkDelta] = _BranchDriver(
-        trunk, scale, scale.shift(None, trunk.now())
+    driver: _BranchDriver[_BranchTime, _TrunkTime, _TrunkDelta] = (
+        _BranchDriver(trunk, scale, scale.shift(None, trunk.now()))
     )
     driver.changeScale(scale)
-    branchScheduler: Scheduler[WhenT, Callable[[], None], int] = (
+    branchScheduler: Scheduler[_BranchTime, Callable[[], None], int] = (
         schedulerFromDriver(driver)
     )
     driver.unpause()
@@ -235,7 +238,7 @@ def _subtract(someFloat: _F, other: _F) -> _F:
 
 
 @dataclass
-class _BranchDriver(Generic[_TrunkTime, _BranchTime, _TrunkDelta]):
+class _BranchDriver(Generic[_BranchTime, _TrunkTime, _TrunkDelta]):
     """
     Implementation of L{TimeDriver} for L{Scheduler} that is stacked on top of
     another L{Scheduler}.


### PR DESCRIPTION
- add `fritter.drivers.datetimes.DateScale` which allows for branching from a float scheduler to a DateTime-based scheduler
- fix `BranchManager` protocol to have discrete branch and trunk time variables
