### PR TITLE
Discrete simulation

### DIFF
--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -81,9 +81,10 @@ class MemoryDriver:
         than C{.now()}, it will be run without adjusting time.
         """
         calls = 0
+        lim = (inf if until is None else until)
         while (
             self._scheduledWork is not None
-            and self._currentTime < (inf if until is None else until)
+            and self._scheduledWork[0] < lim
             and calls < maxCalls
         ):
             calls += 1

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -54,6 +54,10 @@ WhenT = TypeVar("WhenT", bound=Numberish)
 
 @dataclass
 class GeneralMemoryDriver(Generic[WhenT]):
+    """
+    A L{GeneralMemoryDriver} is an in-memory L{TimeDriver} that only moves when
+    L{advance <GeneralMemoryDriver.advance>} is called.
+    """
 
     _currentTime: WhenT
     _scheduledWork: Optional[Tuple[WhenT, Callable[[], None]]]
@@ -147,11 +151,8 @@ class GeneralMemoryDriver(Generic[WhenT]):
 @dataclass
 class MemoryDriver(GeneralMemoryDriver[float]):
     """
-    In-memory L{TimeDriver} that only moves when L{advance
-    <MemoryDriver.advance>} is called.
-
-    @note: This is just a L{GeneralMemoryDriver} with all its defaults
-        populated with reasonable values.
+    A L{MemoryDriver} is a L{GeneralMemoryDriver} for floating-point
+    timestamps, with a bunch of defaults set to reasonable values.
     """
 
     _currentTime: float = 0.0

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -107,15 +107,38 @@ _DriverTypeCheck: type[TimeDriver[float]] = MemoryDriver
 
 @dataclass
 class DiscreteDriver:
+    """
+    A L{DiscreteDriver} advances time in a series of I{discrete steps}, meaning
+    that while your scheduled callable is running, the C{now} value will
+    reflect the time at which your callable was scheduled.
+    """
+
     _driver: TimeDriver[float]
     _discrete: MemoryDriver = field(default_factory=MemoryDriver)
 
     def reschedule(self, desiredTime: float, work: Callable[[], None]) -> None:
+        """
+        Implement L{TimeDriver.reschedule}.
+        """
+
         def step() -> None:
             self._discrete.step(until=self._driver.now())
 
         self._driver.reschedule(desiredTime, step)
         self._discrete.reschedule(desiredTime, work)
 
+    def unschedule(self) -> None:
+        """
+        Implement L{TimeDriver.unschedule}.
+        """
+        self._driver.unschedule()
+        self._discrete.unschedule()
+
     def now(self) -> float:
+        """
+        Implement L{TimeDriver.now}.
+        """
         return self._discrete.now()
+
+
+_DriverTypeCheck2: type[TimeDriver[float]] = DiscreteDriver

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -5,7 +5,7 @@ In-memory implementation of L{TimeDriver} for use in tests and batch scripts.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import inf, nextafter
 from typing import Callable, Optional, Tuple
 
@@ -103,3 +103,19 @@ class MemoryDriver:
 
 
 _DriverTypeCheck: type[TimeDriver[float]] = MemoryDriver
+
+
+@dataclass
+class DiscreteDriver:
+    _driver: TimeDriver[float]
+    _discrete: MemoryDriver = field(default_factory=MemoryDriver)
+
+    def reschedule(self, desiredTime: float, work: Callable[[], None]) -> None:
+        def step() -> None:
+            self._discrete.step(until=self._driver.now())
+
+        self._driver.reschedule(desiredTime, step)
+        self._discrete.reschedule(desiredTime, work)
+
+    def now(self) -> float:
+        return self._discrete.now()

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -8,7 +8,16 @@ from __future__ import annotations
 from types import NotImplementedType
 from dataclasses import dataclass, field
 from math import inf, nextafter
-from typing import Callable, Optional, Protocol, Tuple, Self, TYPE_CHECKING
+from typing import (
+    Callable,
+    Optional,
+    Protocol,
+    Tuple,
+    Self,
+    TYPE_CHECKING,
+    TypeVar,
+    Generic,
+)
 
 from fritter.boundaries import PriorityComparable
 
@@ -20,6 +29,7 @@ class Numberish(PriorityComparable, Protocol):
     Minimal abstract type to describe L{GeneralMemoryDriver}'s requirements of
     its value.
     """
+
     def __sub__(self, other: Self) -> Self: ...
     def __lt__(self, other: Self) -> bool | NotImplementedType: ...
     def __add__(self, other: Self) -> Self: ...
@@ -28,14 +38,17 @@ class Numberish(PriorityComparable, Protocol):
 if TYPE_CHECKING:
     from decimal import Decimal
     from fractions import Fraction
+
     _numberishDescribesFloat: Numberish = 0.0
     _numberishDescribesInt: Numberish = 0
     _numberishDescribesDecimal: Numberish = Decimal()
     _numberishDescribesFraction: Numberish = Fraction()
 
+WhenT = TypeVar("WhenT", bound=Numberish)
+
 
 @dataclass
-class GeneralMemoryDriver[WhenT: Numberish]:
+class GeneralMemoryDriver(Generic[WhenT]):
 
     _currentTime: WhenT
     _scheduledWork: Optional[Tuple[WhenT, Callable[[], None]]]

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -81,10 +81,9 @@ class MemoryDriver:
         than C{.now()}, it will be run without adjusting time.
         """
         calls = 0
-        lim = (inf if until is None else until)
         while (
             self._scheduledWork is not None
-            and self._scheduledWork[0] < lim
+            and self._scheduledWork[0] < (inf if until is None else until)
             and calls < maxCalls
         ):
             calls += 1

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -168,17 +168,17 @@ _DriverTypeCheck: type[TimeDriver[float]] = MemoryDriver
 
 
 @dataclass
-class DiscreteDriver:
+class DiscreteDriver(Generic[WhenT]):
     """
     A L{DiscreteDriver} advances time in a series of I{discrete steps}, meaning
     that while your scheduled callable is running, the C{now} value will
     reflect the time at which your callable was scheduled.
     """
 
-    _driver: TimeDriver[float]
-    _discrete: MemoryDriver = field(default_factory=MemoryDriver)
+    _discrete: GeneralMemoryDriver[WhenT]
+    _driver: TimeDriver[WhenT]
 
-    def reschedule(self, desiredTime: float, work: Callable[[], None]) -> None:
+    def reschedule(self, desiredTime: WhenT, work: Callable[[], None]) -> None:
         """
         Implement L{TimeDriver.reschedule}.
         """
@@ -196,9 +196,9 @@ class DiscreteDriver:
         self._driver.unschedule()
         self._discrete.unschedule()
 
-    def now(self) -> float:
+    def now(self) -> WhenT:
         """
-        Implement L{TimeDriver.now}.
+        Return the time of the currently running, or last run scheduled work.
         """
         return self._discrete.now()
 

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -5,24 +5,45 @@ In-memory implementation of L{TimeDriver} for use in tests and batch scripts.
 
 from __future__ import annotations
 
+from types import NotImplementedType
 from dataclasses import dataclass, field
 from math import inf, nextafter
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Protocol, Tuple, Self, TYPE_CHECKING
+
+from fritter.boundaries import PriorityComparable
 
 from ..boundaries import TimeDriver
 
 
+class Numberish(PriorityComparable, Protocol):
+    """
+    Minimal abstract type to describe L{GeneralMemoryDriver}'s requirements of
+    its value.
+    """
+    def __sub__(self, other: Self) -> Self: ...
+    def __lt__(self, other: Self) -> bool | NotImplementedType: ...
+    def __add__(self, other: Self) -> Self: ...
+
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+    from fractions import Fraction
+    _numberishDescribesFloat: Numberish = 0.0
+    _numberishDescribesInt: Numberish = 0
+    _numberishDescribesDecimal: Numberish = Decimal()
+    _numberishDescribesFraction: Numberish = Fraction()
+
+
 @dataclass
-class MemoryDriver:
-    """
-    In-memory L{TimeDriver} that only moves when L{advance
-    <MemoryDriver.advance>} is called.
-    """
+class GeneralMemoryDriver[WhenT: Numberish]:
 
-    _currentTime: float = 0.0
-    _scheduledWork: Optional[Tuple[float, Callable[[], None]]] = None
+    _currentTime: WhenT
+    _scheduledWork: Optional[Tuple[WhenT, Callable[[], None]]]
+    _nextgreater: Callable[[WhenT], WhenT]
+    _zero: WhenT
+    _inf: WhenT
 
-    def reschedule(self, desiredTime: float, work: Callable[[], None]) -> None:
+    def reschedule(self, desiredTime: WhenT, work: Callable[[], None]) -> None:
         """
         Schedule the given work to happen at the given time.
 
@@ -36,21 +57,21 @@ class MemoryDriver:
 
         @see: L{TimeDriver.reschedule}
         """
-        minInterval = nextafter(self._currentTime, inf)
+        minInterval = self._nextgreater(self._currentTime)
         self._scheduledWork = max(minInterval, desiredTime), work
 
     def unschedule(self) -> None:
         "L{TimeDriver.unschedule}"
         self._scheduledWork = None
 
-    def now(self) -> float:
+    def now(self) -> WhenT:
         "L{TimeDriver.now}"
         return self._currentTime
 
     # |   memory driver only  |
     # v                       v
 
-    def advance(self, delta: Optional[float] = None) -> float | None:
+    def advance(self, delta: WhenT | None = None) -> WhenT | None:
         """
         Advance the clock of L{this driver <MemoryDriver>} by C{delta} seconds.
 
@@ -62,7 +83,9 @@ class MemoryDriver:
         """
         if delta is None:
             if self._scheduledWork is not None:
-                delta = max(0, self._scheduledWork[0] - self._currentTime)
+                delta = max(
+                    self._zero, self._scheduledWork[0] - self._currentTime
+                )
             else:
                 return None
         self._currentTime += delta
@@ -74,7 +97,7 @@ class MemoryDriver:
             what()
         return delta
 
-    def step(self, until: float | None = None, maxCalls: int = 100) -> int:
+    def step(self, until: WhenT | None = None, maxCalls: int = 100) -> int:
         """
         If any work is scheduled, move the clock forward (but only forward) to
         exactly the time that the work is due.  If work is scheduled earlier
@@ -83,7 +106,8 @@ class MemoryDriver:
         calls = 0
         while (
             self._scheduledWork is not None
-            and self._scheduledWork[0] < (inf if until is None else until)
+            and self._scheduledWork[0]
+            < (self._inf if until is None else until)
             and calls < maxCalls
         ):
             calls += 1
@@ -100,6 +124,25 @@ class MemoryDriver:
         Does this driver currently have work scheduled with it?
         """
         return self._scheduledWork is not None
+
+
+@dataclass
+class MemoryDriver(GeneralMemoryDriver[float]):
+    """
+    In-memory L{TimeDriver} that only moves when L{advance
+    <MemoryDriver.advance>} is called.
+
+    @note: This is just a L{GeneralMemoryDriver} with all its defaults
+        populated with reasonable values.
+    """
+
+    _currentTime: float = 0.0
+    _scheduledWork: Optional[Tuple[float, Callable[[], None]]] = None
+    _nextgreater: Callable[[float], float] = field(
+        default_factory=lambda: lambda it: nextafter(it, inf)
+    )
+    _zero: float = 0.0
+    _inf: float = inf
 
 
 _DriverTypeCheck: type[TimeDriver[float]] = MemoryDriver

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -1,3 +1,4 @@
+# -*- test-case-name: fritter.test.test_testing -*-
 """
 In-memory implementation of L{TimeDriver} for use in tests and batch scripts.
 """
@@ -72,6 +73,27 @@ class MemoryDriver:
             self._scheduledWork = None
             what()
         return delta
+
+    def step(self, until: float | None = None, maxCalls: int = 100) -> int:
+        """
+        If any work is scheduled, move the clock forward (but only forward) to
+        exactly the time that the work is due.  If work is scheduled earlier
+        than C{.now()}, it will be run without adjusting time.
+        """
+        calls = 0
+        while (
+            self._scheduledWork is not None
+            and self._currentTime < (inf if until is None else until)
+            and calls < maxCalls
+        ):
+            calls += 1
+            desiredTime, work = self._scheduledWork
+            self._currentTime = max(desiredTime, self._currentTime)
+            self._scheduledWork = None
+            work()
+        if until is not None:
+            self._currentTime = until
+        return calls
 
     def isScheduled(self) -> bool:
         """

--- a/src/fritter/drivers/memory.py
+++ b/src/fritter/drivers/memory.py
@@ -13,11 +13,16 @@ from typing import (
     Optional,
     Protocol,
     Tuple,
-    Self,
     TYPE_CHECKING,
     TypeVar,
     Generic,
 )
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from fritter.boundaries import PriorityComparable
 

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -184,6 +184,11 @@ class MemoryDriverTests(TestCase):
         pretendReal.advance(9.1)
         self.assertEqual(when, [3.0, 6.0, 9.0])
         self.assertEqual(count, 3)
+        self.assertEqual(pretendReal.isScheduled(), True)
+        self.assertEqual(discrete._discrete.isScheduled(), True)
+        discrete.unschedule()
+        self.assertEqual(pretendReal.isScheduled(), False)
+        self.assertEqual(discrete._discrete.isScheduled(), False)
 
     def test_continuousDriver(self) -> None:
         """

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -120,11 +120,13 @@ class MemoryDriverTests(TestCase):
         discrete = DiscreteDriver(pretendReal)
         count = 0
         when = []
+
         def repeat() -> None:
             nonlocal count
             count += 1
-            when.append(now:=discrete.now())
+            when.append(now := discrete.now())
             discrete.reschedule(now + 3.0, repeat)
+
         discrete.reschedule(3.0, repeat)
         pretendReal.advance(9.1)
         self.assertEqual(when, [3.0, 6.0, 9.0])
@@ -134,11 +136,13 @@ class MemoryDriverTests(TestCase):
         continuous = MemoryDriver()
         count = 0
         when = []
+
         def repeat() -> None:
             nonlocal count
             count += 1
-            when.append(now:=continuous.now())
+            when.append(now := continuous.now())
             continuous.reschedule(now + 3.0, repeat)
+
         continuous.reschedule(3.0, repeat)
         continuous.advance(9.1)
         self.assertEqual(when, [9.1])

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ..drivers.memory import MemoryDriver
+from ..drivers.memory import MemoryDriver, DiscreteDriver
 
 
 epsilon = 1e-100
@@ -114,3 +114,32 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(count, 100)
         self.assertGreater(driver.now(), 10.0)
         self.assertLess(10 - driver.now(), epsilon)
+
+    def test_discrete_driver(self) -> None:
+        pretendReal = MemoryDriver()
+        discrete = DiscreteDriver(pretendReal)
+        count = 0
+        when = []
+        def repeat() -> None:
+            nonlocal count
+            count += 1
+            when.append(now:=discrete.now())
+            discrete.reschedule(now + 3.0, repeat)
+        discrete.reschedule(3.0, repeat)
+        pretendReal.advance(9.1)
+        self.assertEqual(when, [3.0, 6.0, 9.0])
+        self.assertEqual(count, 3)
+
+    def test_continuous_driver(self) -> None:
+        continuous = MemoryDriver()
+        count = 0
+        when = []
+        def repeat() -> None:
+            nonlocal count
+            count += 1
+            when.append(now:=continuous.now())
+            continuous.reschedule(now + 3.0, repeat)
+        continuous.reschedule(3.0, repeat)
+        continuous.advance(9.1)
+        self.assertEqual(when, [9.1])
+        self.assertEqual(count, 1)

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from ..drivers.memory import MemoryDriver, DiscreteDriver
-
+from ..boundaries import TimeDriver
+from ..drivers.memory import DiscreteDriver, MemoryDriver
 
 epsilon = 1e-100
 
@@ -166,11 +166,12 @@ class MemoryDriverTests(TestCase):
         simulates a discrete time simulation by remembering the I{scheduled}
         time of each callable as it runs, as its value for
         L{DiscreteDriver.now}, thus making it possible for code to know what
-        time it was I{supposed} to be run at (i.e. when its discrete invocation
-        time was) rather than what it was actually invoked.
+        time it was I{supposed} to be run at (i.e. when its I{scheduled}
+        invocation time was) rather than when it was actually invoked.
         """
         pretendReal = MemoryDriver()
-        discrete = DiscreteDriver(pretendReal)
+        forDiscrete: TimeDriver[float] = pretendReal
+        discrete = DiscreteDriver(MemoryDriver(), forDiscrete)
         count = 0
         when = []
 

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -7,7 +7,20 @@ epsilon = 1e-100
 
 
 class MemoryDriverTests(TestCase):
+    """
+    Tests for L{MemoryDriver}.
+    """
     def test_advance(self) -> None:
+        """
+        L{MemoryDriver.advance} advances its internal clock adn runs its
+        scheduled work.
+
+            - when given a value, it advances by an amount of time represented
+              by that value
+
+            - when given no value, it advances to the time of the scheduled
+              work.
+        """
         driver = MemoryDriver()
         work = []
         self.assertEqual(driver.isScheduled(), False)
@@ -22,6 +35,10 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(driver.advance(), None)
 
     def test_noBackwards(self) -> None:
+        """
+        When work is scheduled in the past, time on L{MemoryDriver.advance}
+        does not move backwards, but advances by a small epsilon.
+        """
         driver = MemoryDriver()
         count = 0
 
@@ -37,6 +54,10 @@ class MemoryDriverTests(TestCase):
         self.assertLess(driver.now(), 1e-20)
 
     def test_step(self) -> None:
+        """
+        L{MemoryDriver.step} will invoke the drivers's work its invocations
+        before returning limited, by default, to 100.
+        """
         driver = MemoryDriver()
         self.assertEqual(driver.isScheduled(), False)
         count = 0
@@ -52,7 +73,13 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(count, 100)
         self.assertTrue(driver.now() < epsilon)
 
-    def test_step2(self) -> None:
+    def test_stepNowAdvancesSynchronously(self) -> None:
+        """
+        L{MemoryDriver.step} will limit its number of synchronous invocations
+        to a limit described by its C{maxCalls} parameter.  Each invocation
+        will have C{driver.now()} set to the time that was passed to
+        L{MemoryDriver.reschedule}.
+        """
         driver = MemoryDriver()
         count = 0
         nows = []
@@ -73,19 +100,31 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(driver.now(), 110.0)
         self.assertEqual(nows, [10.0, 30.0, 50.0, 70.0, 90.0, 110.0])
 
-    def test_step0(self) -> None:
+    def test_stepUntil(self) -> None:
+        """
+        L{MemoryDriver.step} takes an C{until} parameter which describes an
+        upper limit of the time that it will advance the driver's C{.now()} to.
+        """
         driver = MemoryDriver()
         steps = driver.step(until=5.0)
         self.assertEqual(steps, 0)
         self.assertEqual(driver.now(), 5.0)
 
-    def test_step00(self) -> None:
+    def test_stepNothing(self) -> None:
+        """
+        If no work is scheduled, L{MemoryDriver.step} does nothing, not
+        advancing time at all.
+        """
         driver = MemoryDriver()
         steps = driver.step()
         self.assertEqual(steps, 0)
         self.assertEqual(driver.now(), 0.0)
 
-    def test_step1(self) -> None:
+    def test_stepOnce(self) -> None:
+        """
+        If a callable doesn't reschedule itself, L{MemoryDriver.step} will run
+        it once and advance to its time.
+        """
         driver = MemoryDriver()
         count = 0
 
@@ -99,7 +138,12 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(count, 1)
         self.assertEqual(driver.now(), 10.0)
 
-    def test_step_early(self) -> None:
+    def test_stepMuchEarlier(self) -> None:
+        """
+        If a callable scheduled with L{MemoryDriver.reschedule} calls
+        C{reschedule} again with a time far in the past, L{MemoryDriver.step}
+        will advance time by a tiny epsilon and not move time backwards.
+        """
         driver = MemoryDriver()
         count = 0
 
@@ -115,7 +159,15 @@ class MemoryDriverTests(TestCase):
         self.assertGreater(driver.now(), 10.0)
         self.assertLess(10 - driver.now(), epsilon)
 
-    def test_discrete_driver(self) -> None:
+    def test_discreteDriver(self) -> None:
+        """
+        L{DiscreteDriver} wraps a time driver and a L{MemoryDriver}, and
+        simulates a discrete time simulation by remembering the I{scheduled}
+        time of each callable as it runs, as its value for
+        L{DiscreteDriver.now}, thus making it possible for code to know what
+        time it was I{supposed} to be run at (i.e. when its discrete invocation
+        time was) rather than what it was actually invoked.
+        """
         pretendReal = MemoryDriver()
         discrete = DiscreteDriver(pretendReal)
         count = 0
@@ -132,7 +184,12 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(when, [3.0, 6.0, 9.0])
         self.assertEqual(count, 3)
 
-    def test_continuous_driver(self) -> None:
+    def test_continuousDriver(self) -> None:
+        """
+        As opposed to L{MemoryDriver.step}, L{MemoryDriver.advance} advances
+        the value of C{.now()} immediately, so that each invoked callable will
+        see that "real" time rather than the time they were scheduled at.
+        """
         continuous = MemoryDriver()
         count = 0
         when = []

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -3,6 +3,9 @@ from unittest import TestCase
 from ..drivers.memory import MemoryDriver
 
 
+epsilon = 1e-100
+
+
 class MemoryDriverTests(TestCase):
     def test_advance(self) -> None:
         driver = MemoryDriver()
@@ -32,3 +35,66 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(count, 1)
         self.assertGreater(driver.now(), 0.0)
         self.assertLess(driver.now(), 1e-20)
+
+    def test_step(self) -> None:
+        driver = MemoryDriver()
+        self.assertEqual(driver.isScheduled(), False)
+        count = 0
+
+        def forever() -> None:
+            nonlocal count
+            count += 1
+            driver.reschedule(0, forever)
+
+        driver.reschedule(0, forever)
+        steps = driver.step()
+        self.assertEqual(steps, 100)
+        self.assertEqual(count, 100)
+        self.assertTrue(driver.now() < epsilon)
+
+    def test_step2(self) -> None:
+        driver = MemoryDriver()
+        count = 0
+        nows = []
+
+        def add20() -> None:
+            nonlocal count
+            count += 1
+            nows.append(driver.now())
+            driver.reschedule(driver.now() + 20.0, add20)
+
+        driver.reschedule(10.0, add20)
+        steps = driver.step(maxCalls=5)
+        self.assertEqual(steps, 5)
+        self.assertEqual(count, 5)
+        self.assertEqual(driver.now(), 90.0)
+        steps = driver.step(maxCalls=1)
+        self.assertEqual(steps, 1)
+        self.assertEqual(driver.now(), 110.0)
+        self.assertEqual(nows, [10.0, 30.0, 50.0, 70.0, 90.0, 110.0])
+
+    def test_step0(self) -> None:
+        driver = MemoryDriver()
+        steps = driver.step(until=5.0)
+        self.assertEqual(steps, 0)
+        self.assertEqual(driver.now(), 5.0)
+
+    def test_step00(self) -> None:
+        driver = MemoryDriver()
+        steps = driver.step()
+        self.assertEqual(steps, 0)
+        self.assertEqual(driver.now(), 0.0)
+
+    def test_step1(self) -> None:
+        driver = MemoryDriver()
+        count = 0
+
+        def justOnce() -> None:
+            nonlocal count
+            count += 1
+
+        driver.reschedule(10.0, justOnce)
+        steps = driver.step()
+        self.assertEqual(steps, 1)
+        self.assertEqual(count, 1)
+        self.assertEqual(driver.now(), 10.0)

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -10,6 +10,7 @@ class MemoryDriverTests(TestCase):
     """
     Tests for L{MemoryDriver}.
     """
+
     def test_advance(self) -> None:
         """
         L{MemoryDriver.advance} advances its internal clock adn runs its

--- a/src/fritter/test/test_testing.py
+++ b/src/fritter/test/test_testing.py
@@ -98,3 +98,19 @@ class MemoryDriverTests(TestCase):
         self.assertEqual(steps, 1)
         self.assertEqual(count, 1)
         self.assertEqual(driver.now(), 10.0)
+
+    def test_step_early(self) -> None:
+        driver = MemoryDriver()
+        count = 0
+
+        def early() -> None:
+            nonlocal count
+            count += 1
+            driver.reschedule(0.0, early)
+
+        driver.reschedule(10.0, early)
+        steps = driver.step()
+        self.assertEqual(steps, 100)
+        self.assertEqual(count, 100)
+        self.assertGreater(driver.now(), 10.0)
+        self.assertLess(10 - driver.now(), epsilon)


### PR DESCRIPTION
add a time driver that will have a `.now()` which returns a timestamp that reflects the desired time of the scheduled work, with the caveat that it is monotonically increasing and does not move backward for work scheduled in the past.